### PR TITLE
1.2.4 Раздача папки runs/

### DIFF
--- a/markup_ml/main.py
+++ b/markup_ml/main.py
@@ -373,6 +373,7 @@ async def export_run(run_id: str, format: Optional[str] = "json"):
     return JSONResponse(detail)
 
 
+app.mount("/runs", StaticFiles(directory="runs"), name="runs")
 app.mount("/", StaticFiles(directory="static", html=True), name="static")
 
 if __name__ == "__main__":


### PR DESCRIPTION
Подключена вторая директория StaticFiles для папки [runs/]
Фронтенд может запрашивать результаты обучения напрямую из папки [runs/]
Права доступа ограничены только чтением (поведение StaticFiles по умолчанию)
#9 