### PR TITLE
1.2.2 YAML генератор

### DIFF
--- a/markup_ml/app/core/yaml_generator.py
+++ b/markup_ml/app/core/yaml_generator.py
@@ -1,0 +1,37 @@
+import os
+import yaml
+
+def generate_yolo_yaml(dataset_path: str, num_classes: int) -> str:
+    abs_dataset_path = os.path.abspath(dataset_path)
+    os.makedirs(abs_dataset_path, exist_ok=True)
+
+    yaml_data = {
+        "path": abs_dataset_path,
+        "train": "images/train",  # Пути вводить относительно 'path'
+        "val": "images/val",      
+        "test": "images/test",    
+        "nc": num_classes,
+        "names": [f"class_{i}" for i in range(num_classes)]
+    }
+
+    yaml_file_path = os.path.join(abs_dataset_path, "data.yaml")
+    with open(yaml_file_path, "w", encoding="utf-8") as file_YOLO:
+        yaml.dump(yaml_data, file_YOLO, default_flow_style=False, sort_keys=False, allow_unicode=True)
+        
+    return yaml_file_path
+
+'''
+    if __name__ == "__main__":
+    # Тестовые входные данные
+    test_path = "./my_custom_dataset"
+    classes_count = 5
+    
+    # Генерация
+    result_file = generate_yolo_yaml(test_path, classes_count)
+    print(f"The file was successfully generated on path\nПуть: {result_file}")
+    
+    # Проверка содержимого
+    print("-" * 30)
+    with open(result_file, "r", encoding="utf-8") as f:
+        print(f.read())
+'''


### PR DESCRIPTION
- Соответствие формату Ultralytics YOLO. Использовал встроенный дампер "yaml.dump", что исключает синтаксические ошибки.
- Функция оборачивает входную строку в "os.path.abspath()". При передаче относительного пути (например, "datasets/my_data"), внутри YAML он будет записан как полный.
- Файл принудительно формируется и сохраняется по пути "os.path.join(abs_dataset_path, "data.yaml")". Если папки нет, то она будет создана с помощью os.makedirs.
